### PR TITLE
Feature/3 up periscope

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,13 +92,13 @@ running throughout the entire test session:
     import pytest
     from pytest_docker_compose import DockerComposePlugin
 
-    @pytest.fixture(scope="session"):
+    @pytest.fixture(scope="session")
     def session_containers(docker_project):
       containers = DockerComposePlugin._containers_up(docker_project)
       yield containers
       DockerComposePlugin._containers_down(docker_project, containers)
 
-    @pytest.fixture(scope="session"):
+    @pytest.fixture(scope="session")
     def session_network_info(session_containers):
       return DockerComposePlugin._extract_network_info(session_containers)
 

--- a/README.rst
+++ b/README.rst
@@ -14,10 +14,10 @@ Make sure you have `Docker`_ installed.
 
 This plugin has been tested against the following software:
 
-- Python 3.6
-- pytest 3.4 and 3.5.
+- Python 3.6 and 3.5.
+- pytest 3.5 and 3.4.
 
-.. note:: This plugin is not compatible with Python 2.
+.. note:: This plugin is **not** compatible with Python 2.
 
 
 Installation

--- a/pytest_docker_compose/__init__.py
+++ b/pytest_docker_compose/__init__.py
@@ -20,18 +20,18 @@ class NetworkInfo:
     Container for info about how to connect to a service exposed by a
     Docker container.
     """
-    container_port: typing.Text
+    container_port = None  # type: typing.Text
     """
     Port (and usually also protocol name) exposed internally on the
     container.
     """
 
-    hostname: typing.Text
+    hostname = None  # type: typing.Text
     """
     Hostname to use when accessing this service.
     """
 
-    host_port: int
+    host_port = None  # type: int
     """
     Port number to use when accessing this service.
     """
@@ -83,7 +83,7 @@ class DockerComposePlugin:
         This is intentional; stopping the containers destroys local
         storage, so that the next test can start with fresh containers.
         """
-        containers: typing.List[Container] = docker_project.up()
+        containers = docker_project.up()  # type: typing.List[Container]
 
         if not containers:
             raise ValueError("`docker-compose` didn't launch any containers!")
@@ -94,7 +94,7 @@ class DockerComposePlugin:
         # the test report.
         # https://docs.pytest.org/en/latest/capture.html
         for container in sorted(containers, key=lambda c: c.name):
-            header = f"Logs from {container.name}:"
+            header = "Logs from {name}:".format(name=container.name)
             print(header)
             print("=" * len(header))
             print(
@@ -146,7 +146,10 @@ class DockerComposePlugin:
 
         if not docker_compose.is_file():
             raise ValueError(
-                f"Unable to find `{docker_compose}` for integration tests.",
+                "Unable to find `{docker_compose}` "
+                "for integration tests.".format(
+                    docker_compose=docker_compose,
+                ),
             )
 
         project = project_from_options(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name="pytest-docker-compose",
     description="Manages Docker containers during your integration tests",
     long_description=long_description,
-    version="1.0.1",
+    version="1.0.3",
     author="Phoenix Zerin",
     author_email="phoenix.zerin@centrality.ai",
     url="https://github.com/Centraliyai/pytest-docker-compose",


### PR DESCRIPTION
**Note:** Depends on #4

Workaround for #3 

The underlying issue is super complex, but at least this gives users a way to work around the problem, [so long as they are willing to shoulder the burden of managing some of that complexity](https://github.com/centralityai/pytest-docker-compose/issues/3#issuecomment-435627617):

> \[The\] function-scoped `docker_containers` and `docker_network_info` fixtures are still technically accessible. Also, for non-trivial applications, you'll have to implement the code to clean up after each test, etc.