### PR TITLE
Added a 'no-build' option for docker-compose

### DIFF
--- a/pytest_docker_compose/__init__.py
+++ b/pytest_docker_compose/__init__.py
@@ -71,6 +71,9 @@ class DockerComposePlugin:
             help="Path to docker-compose.yml file, or directory containing same.",
         )
 
+        group.addoption("--docker-compose-no-build", action="store_true",
+                        default=False, help="Boolean to not build docker containers")
+
     @pytest.fixture
     def docker_containers(self, docker_project: Project):
         """
@@ -122,7 +125,9 @@ class DockerComposePlugin:
             project_dir=str(docker_compose.parent),
             options={"--file": [docker_compose.name]},
         )
-        project.build()
+
+        if not request.config.getoption("--docker-compose-no-build"):
+            project.build()
 
         return project
 


### PR DESCRIPTION
Hi, I have a fairly large docker-compose file and the build command significantly slows down my testing. Especially when writing tests it is quite unnecessary to rebuild the unchanged code in the container every time.

I have extended the plugin with an optional flag. The default behaviour stays identical but calling pytest with --docker-compose-no-build prevents the plugin from building the containers.