### PR TITLE
fix: detach from containers log stream

### DIFF
--- a/src/pytest_docker_compose/__init__.py
+++ b/src/pytest_docker_compose/__init__.py
@@ -146,7 +146,7 @@ class DockerComposePlugin:
                     "containers won't be used if there are already "
                     "containers running!"))
             current_containers = project.containers()
-            containers = project.up()
+            containers = project.up(detached=True)
             if not set(current_containers) == set(containers):
                 warnings.warn(UserWarning(
                     "You used the '--use-running-containers' but "
@@ -183,7 +183,7 @@ class DockerComposePlugin:
                         'pytest-docker-compose tried to start containers but there are'
                         ' already running containers: %s, you probably scoped your'
                         ' tests wrong' % docker_project.containers())
-                containers = docker_project.up()
+                containers = docker_project.up(detached=True)
                 if not containers:
                     raise ValueError("`docker-compose` didn't launch any containers!")
 


### PR DESCRIPTION
Hello, thank you for the great project.

I was using `pytest-docker-compose` to test one of my projects (FastAPI running on gunicorn), everything was great,
until I added more tests and they started to fail.
They failed in a very particular way, every time on the same test, FastAPI application stoped responding on new requests.
At first, I suspected my code doing something wrong, then gunicorn, than FastAPI, then my sanity. 
After two days of trials and errors I come up with this patch, that fixes my problem.

My suspect is that the process, that starts docker-compose and attaches to containers log stream (in our case it is pytest process), when 
there are a lot of logs meets some limits (I didn't manage to debug further, to find what limits) and blocks container progression.

I do not have the time right now to give you Dockerfile with a sample application that reproduces the problem, but if you need it I will try to do so in a few days.

If you want, I can add a new plugin options, for example, `pytest-docker-compose-detached`, with default set to `False`.