### PR TITLE
Add --docker-compose-service-names option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -173,6 +173,12 @@ Docker compose allows for specifying multiple compose files as described in the 
 
     pytest --docker-compose=/path/to/docker-compose.yml,/another/docker-compose.yml,/third/docker-compose.yml
 
+You can also specify the services to use:
+
+.. code-block:: sh
+
+    pytest --docker-compose-service-names=mysql,redis
+
 .. tip::
     Alternatively, you can specify this option in your ``pytest.ini`` file:
 

--- a/src/pytest_docker_compose/__init__.py
+++ b/src/pytest_docker_compose/__init__.py
@@ -152,7 +152,7 @@ class DockerComposePlugin:
             current_containers = project.containers(service_names=service_names)
             containers = project.up(service_names=service_names)
 
-            if not set(current_containers) == set(containers):
+            if not set(current_containers).issubset(set(containers)):
                 warnings.warn(UserWarning(
                     "You used the '--use-running-containers' but "
                     "pytest-docker-compose could not find all containers "


### PR DESCRIPTION
As a user, I do not always want to boot up all services in a docker-compose file. 

Currently, the only workaround I found was to duplicate the services needed for running the test in a test-specific docker-compose file. And sometimes [extending a service can be impossible](https://github.com/docker/compose/issues/7916).

This PR adds a new `--docker-compose-service-names` option that allows you to specify which services to boot up.